### PR TITLE
Fix python 3 compatibility

### DIFF
--- a/lexibank/datatables.py
+++ b/lexibank/datatables.py
@@ -18,7 +18,7 @@ from clld.web.datatables.source import Sources
 from clld_glottologfamily_plugin.datatables import MacroareaCol, FamilyLinkCol
 from clld_glottologfamily_plugin.models import Family
 
-from models import (
+from .models import (
     LexibankLanguage, Counterpart, Concept, Provider, LexibankSource,
     CounterpartReference, Cognateset,
 )

--- a/lexibank/datatables.py
+++ b/lexibank/datatables.py
@@ -18,7 +18,7 @@ from clld.web.datatables.source import Sources
 from clld_glottologfamily_plugin.datatables import MacroareaCol, FamilyLinkCol
 from clld_glottologfamily_plugin.models import Family
 
-from .models import (
+from lexibank.models import (
     LexibankLanguage, Counterpart, Concept, Provider, LexibankSource,
     CounterpartReference, Cognateset,
 )


### PR DESCRIPTION
Change the models import to an explicit absolute import in datatables.py – This supersedes the explicit relative import suggested in #7 .
